### PR TITLE
fix: remove view column comments

### DIFF
--- a/macros/materialize.jinja
+++ b/macros/materialize.jinja
@@ -34,7 +34,9 @@
         comment if exists on table {{ table_name }} IS '{{ description }}';{{ "\n" }}
         {%- endif -%}
     {%- endif -%}
-    {{ gen_column_comments(table_name) }}
+    {%- if materialization != "view" -%}
+        {{ gen_column_comments(table_name) }}
+    {%- endif -%}
 {%- endmacro -%}
 
 {%- macro gen_column_comments(table_name) -%}


### PR DESCRIPTION
Snowflake does not allow for column comments on views:
```
error: SDF1015: Unable to execute 'sdftarget/dbg/materialized/analytics/aux/stg_python_ingestor__iowa_liquor_sales.sql': Snowflake errored out on the following query:
comment if exists on column ANALYTICS.AUX.STG_PYTHON_INGESTOR__IOWA_LIQUOR_SALES.vendor_name IS 'The name of the company that produced or distributed the liquor product sold.'
Error: Snowflake API error. Code: `002203`. Message: `SQL compilation error: Object found is of type 'VIEW', not specified type 'TABLE'.
```
