### PR TITLE
Adding a new transient table macro to the materializations.jinja

### DIFF
--- a/macros/materialize.jinja
+++ b/macros/materialize.jinja
@@ -23,6 +23,11 @@
 {{ gen_comments(table_name) }}
 {%- endmacro -%}
 
+{%- macro gen_transient_table(table_name, query) -%}
+    create or replace transient table {{ table_name }} as ({{ query }});{{ "\n" }}
+{{ gen_comments(table_name) }}
+{%- endmacro -%}
+
 {%- macro gen_comments(table_name) -%}
     {%- set table = get_table(table_name) -%}
     {%- set description = table[0] -%}
@@ -332,6 +337,8 @@
     {%- elif builtin.materialization == "recursive-table" -%}
         {# Snowflake doesn't have a specific 'recursive table' concept; adjust as needed #}
         {{ gen_table(table_name, query) }}
+    {%- elif builtin.materialization == "transient-table" -%}
+        {{ gen_transient_table(table_name, query) }}
     {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
We want to be able to use transient tables in snowflake with sdf.
This PR creates a new macro `gen_transient_table` and adds that as an option to the `select` macro.
I tested this on our test sdf project and was able to successfully run and compile models with an sdf.yml file by setting `materialization: transient-table`.
